### PR TITLE
Restore Effective Address Signal in `rtl/mips_cpu_bus.v`

### DIFF
--- a/rtl/mips_cpu_bus.v
+++ b/rtl/mips_cpu_bus.v
@@ -51,7 +51,7 @@ module mips_cpu_bus (
 
   // ALU
   logic stall_alu;
-  size_t mfhi, mflo, alu_out;
+  size_t mfhi, mflo, alu_out, effective_address;
 
 
   /* Modules */
@@ -145,6 +145,7 @@ module mips_cpu_bus (
       .immediate_i(immediate),
       .rd_o(rd_data_d),
       .rt_o(rt_data_d),
+      .effective_address_o(effective_address),
       .mfhi_o(mfhi),
       .mflo_o(mflo),
       .stall_o(stall_alu)
@@ -156,7 +157,7 @@ module mips_cpu_bus (
   /* Other IO/IN. */
   assign active = state != HALT;
   assign register_v0 = read_data_reg_v0;
-  assign address = (ram_a_sel == 1) ? alu_out : pc_o;
+  assign address = (ram_a_sel == 1) ? effective_address : pc_o;
   assign writedata = rt_data_d;
   assign byteenable = 4'b1111;  //TODO: Change when LB instructions are implemented.
 


### PR DESCRIPTION
Changes Made:
- Adds effective address signal in `rtl/mips_cpu_bus.v` to ALU.